### PR TITLE
Removed redundant sanity check

### DIFF
--- a/examples/servo/spark.ino
+++ b/examples/servo/spark.ino
@@ -11,15 +11,9 @@ void loop() {
 
 int servowrite(String command)
 {
-        //convert ascii to integer
-        int pinNumber = command.charAt(1) - '0';
-        //Sanity check to see if the pin numbers are within limits
-        if (pinNumber< 0 || pinNumber >7) return -1;
-
-        String value = command.substring(3);
-
         if(command.startsWith("A0"))
         {
+            String value = command.substring(3);
             servo.write(value.toInt());
             return 1;
         }


### PR DESCRIPTION
Removed useless and redundant sanity check on the Pin number, because the `command.startsWith("A0")` portion of the code takes care of it.
Possible improvement : allow to attach new servos at runtime, with another Spark function call, then handle pin number in the `servowrite` function.
