### PR TITLE
Run custom command fixes

### DIFF
--- a/index.js
+++ b/index.js
@@ -56,8 +56,7 @@ Sparky.prototype = {
 			delete this.pinThrottle[params];
 		}
 
-		command = command.toLowerCase();
-		command = 'curl https://api.spark.io/v1/devices/' + this.config.deviceId + '/' + command + '   -d access_token=' + this.config.token + ' -d args=' + params;
+		command = 'curl https://api.spark.io/v1/devices/' + this.config.deviceId + '/' + command + '   -d access_token=' + this.config.token + ' -d "args=' + params+'"';
 		this.debug('Running command: ', command);
 		child = exec(command,
 			function (error, stdout, stderr) {

--- a/index.js
+++ b/index.js
@@ -82,24 +82,28 @@ Sparky.prototype = {
 	 * 0, false -> 'LOW'
 	 */
 	formatDigitalValue: function(value) {
-		return value ? 'HIGH' : 'LOW';
+        if (value == 'HIGH' || value == 'LOW') {
+            return value;
+        } else {
+            return value ? 'HIGH' : 'LOW';
+        }
 	},
 
 	digitalWrite: function(pin, value) {
 		value = this.formatDigitalValue(value);
-		this._command('digitalWrite', pin + ',' + value);
+		this._command('digitalwrite', pin + ',' + value);
 	},
 
 	analogWrite: function(pin, value) {
-		this._command('analogWrite', pin + ',' + value);
+		this._command('analogwrite', pin + ',' + value);
 	},
 
 	digitalRead: function(pin, callback) {
-		this._command('digitalRead', pin, callback);
+		this._command('digitalread', pin, callback);
 	},
 
 	analogRead: function(pin, callback) {
-		this._command('analogRead', pin, callback);
+		this._command('analogread', pin, callback);
 	},
 
 	/**


### PR DESCRIPTION
— Command can now be CamelCase
— args are now sent in double quotes as shown in the documentation

Here is an example of my Spark code:
….
int setBlinkPeriod(String period);

void setup() {
    Spark.function("setBlink", setBlinkPeriod);
}
….
I used camelCase to expose the setBlinkPeriod function on the API.

Here is the working curl call (taken from the documentation):
curl https://api.spark.io/v1/devices/***/setBlink -d access_token=*\* -d "args=123"

When tried to run the same API call via Sparky:
core1.run('setBlink', '123', function(res) {
    console.log(res);
});
with debug option I got a slightly different curl call:
curl https://api.spark.io/v1/devices/**/setblink -d access_token=*\* -d args=123

This patch fixes the above issues.
